### PR TITLE
Status

### DIFF
--- a/avalonstar/apps/live/urls.py
+++ b/avalonstar/apps/live/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls import patterns, include, url
 from django.views.generic import RedirectView
 
 from .views import (AwayView, DiscussionView, EpilogueView, GameView,
-    NotifierView, PrologueView)
+    NotifierView, PrologueView, StatusView)
 
 
 urlpatterns = patterns('',
@@ -18,4 +18,7 @@ urlpatterns = patterns('',
     url(r'^game/$', name='live-game', view=GameView.as_view()),
     url(r'^prologue/$', name='live-prologue', view=PrologueView.as_view()),
     url(r'^notifier/$', name='live-notifier', view=NotifierView.as_view()),
+
+    # Status (for bots).
+    url(r'^status/$', name='live-status', view=StatusView.as_view()),
 )

--- a/avalonstar/apps/live/utils.py
+++ b/avalonstar/apps/live/utils.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import re
+import requests
+
+
+def fetch_stream():
+    endpoint = 'https://api.twitch.tv/kraken/streams/avalonstar'
+    return requests.get(endpoint).json()
+
+
+def fetch_status():
+    try:
+        response = fetch_stream()
+        return response['stream']['channel']['status']
+    except TypeError:
+        return None
+
+
+def is_episodic():
+    pattern = ur'^A\u2606\d{3}'
+    regex = re.compile(pattern, re.UNICODE)

--- a/avalonstar/apps/live/utils.py
+++ b/avalonstar/apps/live/utils.py
@@ -5,26 +5,31 @@ import requests
 
 def fetch_stream():
     endpoint = 'https://api.twitch.tv/kraken/streams/avalonstar'
-    return requests.get(endpoint).json()
+    json = requests.get(endpoint).json()
+    return json.get('stream', {})
 
 
 def fetch_status():
     try:
         response = fetch_stream()
-        return response['stream']['channel']['status']
-    except TypeError:
+        return response.get('channel', {}).get('status', '')
+    except AttributeError, TypeError:
         return ''
 
 
 def is_episodic():
-    # Let's use the stream's title to determine if a stream is "casual"
-    # or not. The current way we determine this is as follows:
+    # Let's use the stream's title to determine if a stream is an episode
+    # or not. We use the stream's status to determine this as follows:
     #
     #   - "A☆###": A numbered episode.
     #   - (Anything else.): A casual episode.
     #
-    # Because Python is weird, it doesn't detect the white star, so we're not
+    # Because Python is weird, it doesn't detect the white star. We're not
     # going to bother looking for it.
     pattern = r'^A.\d{3}'
     status = fetch_status()
     return bool(re.match(pattern, status, re.UNICODE))
+
+
+def is_live():
+    return bool(fetch_stream())

--- a/avalonstar/apps/live/utils.py
+++ b/avalonstar/apps/live/utils.py
@@ -13,9 +13,18 @@ def fetch_status():
         response = fetch_stream()
         return response['stream']['channel']['status']
     except TypeError:
-        return None
+        return ''
 
 
 def is_episodic():
-    pattern = ur'^A\u2606\d{3}'
-    regex = re.compile(pattern, re.UNICODE)
+    # Let's use the stream's title to determine if a stream is "casual"
+    # or not. The current way we determine this is as follows:
+    #
+    #   - "A☆###": A numbered episode.
+    #   - (Anything else.): A casual episode.
+    #
+    # Because Python is weird, it doesn't detect the white star, so we're not
+    # going to bother looking for it.
+    pattern = r'^A.\d{3}'
+    status = fetch_status()
+    return bool(re.match(pattern, status, re.UNICODE))

--- a/avalonstar/apps/live/views.py
+++ b/avalonstar/apps/live/views.py
@@ -37,3 +37,9 @@ class NotifierView(BroadcastContextMixin, TemplateView):
 
 class PrologueView(BroadcastContextMixin, TemplateView):
     template_name = 'live/prologue.html'
+
+
+class StatusView(JSONResponseMixin, View):
+    def get(self, request, *args, **kwargs):
+        context = {'a': fetch_status()}
+        return self.render_json_response(context)

--- a/avalonstar/apps/live/views.py
+++ b/avalonstar/apps/live/views.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.views.generic import TemplateView
 
+from braces.views import JSONResponseMixin
+
 from apps.broadcasts.models import Broadcast
 from apps.live.models import Message
 

--- a/avalonstar/apps/live/views.py
+++ b/avalonstar/apps/live/views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.views.generic import TemplateView, View
 
 from braces.views import JSONResponseMixin

--- a/avalonstar/apps/live/views.py
+++ b/avalonstar/apps/live/views.py
@@ -1,10 +1,11 @@
-# -*- coding: utf-8 -*-
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, View
 
 from braces.views import JSONResponseMixin
 
 from apps.broadcasts.models import Broadcast
 from apps.live.models import Message
+
+from .utils import fetch_status
 
 
 class BroadcastContextMixin(object):

--- a/avalonstar/apps/live/views.py
+++ b/avalonstar/apps/live/views.py
@@ -5,7 +5,7 @@ from braces.views import JSONResponseMixin
 from apps.broadcasts.models import Broadcast
 from apps.live.models import Message
 
-from .utils import fetch_status
+from .utils import fetch_status, is_episodic
 
 
 class BroadcastContextMixin(object):
@@ -42,5 +42,5 @@ class PrologueView(BroadcastContextMixin, TemplateView):
 
 class StatusView(JSONResponseMixin, View):
     def get(self, request, *args, **kwargs):
-        context = {'a': fetch_status()}
+        context = {'is_live': is_episodic()}
         return self.render_json_response(context)

--- a/avalonstar/apps/live/views.py
+++ b/avalonstar/apps/live/views.py
@@ -5,7 +5,7 @@ from braces.views import JSONResponseMixin
 from apps.broadcasts.models import Broadcast
 from apps.live.models import Message
 
-from .utils import fetch_status, is_episodic
+from .utils import fetch_stream, is_episodic
 
 
 class BroadcastContextMixin(object):
@@ -42,5 +42,9 @@ class PrologueView(BroadcastContextMixin, TemplateView):
 
 class StatusView(JSONResponseMixin, View):
     def get(self, request, *args, **kwargs):
-        context = {'is_live': is_episodic()}
+        broadcast = Broadcast.objects.latest()
+        context = {
+            'is_episodic': is_episodic(),
+            'is_live': bool(fetch_stream()),
+            'number': broadcast.number }
         return self.render_json_response(context)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 # Base Project Requirements
 
 Django == 1.7.1
+django-braces == 1.4.0
 django-configurations == 0.8
 django-dotenv == 1.3.0
 django-grappelli == 2.6.3


### PR DESCRIPTION
Previously I had attempted to do a lot of my status checking in my bot, which got unruly. First I would check the Twitch API to see if I was live, _then_ I would check Avalonstar's to see what episode number we were on. 

This changes that by providing an endpoint supplying a "single point of truth" that I can eventually expand on. Both bots can also take advantage of this, helping keep their roles segregated.