### PR TITLE
Record Raids via the API

### DIFF
--- a/avalonstar/settings/base.py
+++ b/avalonstar/settings/base.py
@@ -120,4 +120,14 @@ class Base(Configuration):
 
     # django-rest-framework.
     # --------------------------------------------------------------------------
-    INSTALLED_APPS += ['rest_framework']
+    INSTALLED_APPS += [
+        'rest_framework',
+        'rest_framework.authtoken'
+    ]
+    REST_FRAMEWORK = {
+        'DEFAULT_AUTHENTICATION_CLASSES': (
+            'rest_framework.authentication.BasicAuthentication',
+            'rest_framework.authentication.SessionAuthentication',
+            'rest_framework.authentication.TokenAuthentication'
+        )
+    }


### PR DESCRIPTION
Historically we've used Firebase to record raids, which then in turn need to be imported into Django's DB. This eliminates that middle step, although most of the work is being done in atvbot.