### PR TITLE
Add `created` to Ticket

### DIFF
--- a/avalonstar/apps/subscribers/admin.py
+++ b/avalonstar/apps/subscribers/admin.py
@@ -5,7 +5,7 @@ from .models import Ticket
 
 
 class TicketAdmin(admin.ModelAdmin):
-    list_display = ['name', 'display_name', 'subscribed', 'is_active', 'is_paid', 'twid']
+    list_display = ['name', 'display_name', 'updated', 'is_active', 'is_paid', 'twid']
     list_editable = ['is_active', 'is_paid']
-    ordering = ['-subscribed']
+    ordering = ['-updated']
 admin.site.register(Ticket, TicketAdmin)

--- a/avalonstar/apps/subscribers/admin.py
+++ b/avalonstar/apps/subscribers/admin.py
@@ -5,7 +5,7 @@ from .models import Ticket
 
 
 class TicketAdmin(admin.ModelAdmin):
-    list_display = ['name', 'display_name', 'updated', 'is_active', 'is_paid', 'twid']
-    list_editable = ['is_active', 'is_paid']
+    list_display = ['name', 'display_name', 'created', 'updated', 'is_active', 'is_paid', 'twid']
+    list_editable = ['created', 'updated', 'is_active', 'is_paid']
     ordering = ['-updated']
 admin.site.register(Ticket, TicketAdmin)

--- a/avalonstar/apps/subscribers/management/commands/updatetickets.py
+++ b/avalonstar/apps/subscribers/management/commands/updatetickets.py
@@ -58,7 +58,7 @@ class Command(NoArgsCommand):
                 updates = {
                         'display_name': ticket['user']['display_name'],
                         'is_active': True,
-                        'subscribed': ticket['created_at'],
+                        'updated': ticket['created_at'],
                         'twid': ticket['_id'] }
                 t, created = Ticket.objects.update_or_create(name=name, defaults=updates)
 

--- a/avalonstar/apps/subscribers/migrations/0008_auto_20150321_1509.py
+++ b/avalonstar/apps/subscribers/migrations/0008_auto_20150321_1509.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+import datetime
+from django.utils.timezone import utc
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subscribers', '0007_auto_20150309_1854'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='ticket',
+            options={'ordering': ['updated']},
+        ),
+        migrations.RenameField(
+            model_name='ticket',
+            old_name='subscribed',
+            new_name='updated'
+        ),
+        migrations.AlterField(
+            model_name='count',
+            name='timestamp',
+            field=models.DateTimeField(default=datetime.datetime(2015, 3, 21, 22, 9, 37, 300476, tzinfo=utc)),
+            preserve_default=True,
+        ),
+    ]

--- a/avalonstar/apps/subscribers/migrations/0009_auto_20150321_1521.py
+++ b/avalonstar/apps/subscribers/migrations/0009_auto_20150321_1521.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subscribers', '0008_auto_20150321_1509'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ticket',
+            name='created',
+            field=models.DateTimeField(default=django.utils.timezone.now),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='count',
+            name='timestamp',
+            field=models.DateTimeField(default=datetime.datetime(2015, 3, 21, 22, 21, 7, 920762, tzinfo=utc)),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='ticket',
+            name='updated',
+            field=models.DateTimeField(default=django.utils.timezone.now),
+            preserve_default=True,
+        ),
+    ]

--- a/avalonstar/apps/subscribers/models.py
+++ b/avalonstar/apps/subscribers/models.py
@@ -39,8 +39,8 @@ class Ticket(models.Model):
     twid = models.CharField(blank=True, max_length=40)
     name = models.CharField(max_length=200)
     display_name = models.CharField(blank=True, max_length=200)
-    subscribed = models.DateTimeField(default=timezone.now,
-        help_text=u'When did the user subscribe?')
+    created = models.DateTimeField(default=timezone.now)
+    updated = models.DateTimeField(default=timezone.now)
 
     # Is this subscription active?
     # TODO: Run a script that deactivates subs after XX days.
@@ -53,13 +53,13 @@ class Ticket(models.Model):
     objects = TicketManager()
 
     class Meta:
-        ordering = ['subscribed']
+        ordering = ['updated']
 
     def __unicode__(self):
         return u'%s' % self.name
 
     def update(self, **kwargs):
-        allowed_attributes = {'twid', 'display_name', 'subscribed', 'is_active'}
+        allowed_attributes = {'twid', 'display_name', 'updated', 'is_active'}
         for name, value in kwargs.items():
             assert name in allowed_attributes
             setattr(self, name, value)


### PR DESCRIPTION
Twitch's API changes the `created_at` date of subscriptions whenever a subscription is renewed, even if that subscription is part of a substreak. In order to have an accurate representation of how long somebody has been a subscriber (outside of the simple substreak number), we need to have both `created` and `updated` fields.