### PR TITLE
Standardize Raider and Hoster Fields

### DIFF
--- a/avalonstar/apps/broadcasts/admin.py
+++ b/avalonstar/apps/broadcasts/admin.py
@@ -50,12 +50,12 @@ admin.site.register(Highlight, HighlightAdmin)
 
 
 class HostAdmin(admin.ModelAdmin):
-    list_display = ['timestamp', 'hoster', 'broadcast']
+    list_display = ['timestamp', 'username', 'broadcast']
 admin.site.register(Host, HostAdmin)
 
 
 class RaidAdmin(admin.ModelAdmin):
-    list_display = ['timestamp', 'broadcast', 'raider', 'game']
+    list_display = ['timestamp', 'broadcast', 'username', 'game']
 admin.site.register(Raid, RaidAdmin)
 
 

--- a/avalonstar/apps/broadcasts/migrations/0012_auto_20150407_2220.py
+++ b/avalonstar/apps/broadcasts/migrations/0012_auto_20150407_2220.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('broadcasts', '0011_auto_20150305_1111'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='host',
+            old_name='hoster',
+            new_name='username',
+        ),
+        migrations.RenameField(
+            model_name='raid',
+            old_name='raider',
+            new_name='username',
+        ),
+    ]

--- a/avalonstar/apps/broadcasts/models.py
+++ b/avalonstar/apps/broadcasts/models.py
@@ -96,21 +96,21 @@ class Host(models.Model):
     broadcast = models.ForeignKey(Broadcast, related_name='hosts')
     timestamp = models.DateTimeField(default=timezone.now,
         help_text=u'When did it happen?')
-    hoster = models.CharField(blank=True, max_length=200)
+    username = models.CharField(blank=True, max_length=200)
 
     class Meta:
         order_with_respect_to = u'broadcast'
         ordering = ['timestamp']
 
     def __unicode__(self):
-        return u'%s' % self.hoster
+        return u'%s' % self.username
 
 
 class Raid(models.Model):
     broadcast = models.ForeignKey(Broadcast, related_name='raids')
     timestamp = models.DateTimeField(default=timezone.now,
         help_text=u'When did it happen?')
-    raider = models.CharField(blank=True, max_length=200)
+    username = models.CharField(blank=True, max_length=200)
 
     # Silly metadata.
     game = models.CharField(blank=True, max_length=200,
@@ -121,4 +121,4 @@ class Raid(models.Model):
         ordering = ['timestamp']
 
     def __unicode__(self):
-        return u'%s' % self.raider
+        return u'%s' % self.username

--- a/avalonstar/apps/subscribers/migrations/0012_auto_20150407_2220.py
+++ b/avalonstar/apps/subscribers/migrations/0012_auto_20150407_2220.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subscribers', '0011_auto_20150403_1805'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='count',
+            name='timestamp',
+            field=models.DateTimeField(default=datetime.datetime(2015, 4, 8, 5, 20, 30, 926786, tzinfo=utc)),
+            preserve_default=True,
+        ),
+    ]

--- a/avalonstar/settings/base.py
+++ b/avalonstar/settings/base.py
@@ -34,7 +34,9 @@ class Base(Configuration):
         'apps.live',
         'apps.subscribers',
     ]
-    PLUGINS = []
+    PLUGINS = [
+        'corsheaders'
+    ]
     ADMINISTRATION = [
         'grappelli',
         'django.contrib.admin',
@@ -45,6 +47,7 @@ class Base(Configuration):
     # --------------------------------------------------------------------------
     MIDDLEWARE_CLASSES = (
         'django.contrib.sessions.middleware.SessionMiddleware',
+        'corsheaders.middleware.CorsMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/avalonstar/settings/development.py
+++ b/avalonstar/settings/development.py
@@ -26,3 +26,7 @@ class Development(Settings):
     # --------------------------------------------------------------------------
     CDN_DOMAIN = 'http://avalonstar-tv.s3.amazonaws.com'
     MEDIA_URL = '%s/' % (CDN_DOMAIN)
+
+    # django-cors-headers
+    # --------------------------------------------------------------------------
+    CORS_ORIGIN_ALLOW_ALL = True

--- a/avalonstar/templates/broadcasts/broadcast_detail.html
+++ b/avalonstar/templates/broadcasts/broadcast_detail.html
@@ -23,7 +23,7 @@
   <ul class="raid-list">
   {% for raid in object.raids.all %}
     <li class="raid">
-      <a href="http://twitch.tv/{{ raid.raider }}">{{ raid.raider }}</a>
+      <a href="http://twitch.tv/{{ raid.username }}">{{ raid.username }}</a>
       {{ raid.game }}
       {{ raid.timestamp }}
     </li>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,12 +3,13 @@
 Django == 1.7.7
 django-braces == 1.4.0
 django-configurations == 0.8
+django-cors-headers == 1.0.0
 django-dotenv == 1.3.0
 django-grappelli == 2.6.4
 django-heroku-postgresify == 0.3
 django-model-utils == 2.2
 djangorestframework == 3.1.1
-requests == 2.6.0
 Pillow == 2.8.0
 psycopg2 == 2.6
+requests == 2.6.0
 whitenoise == 1.0.6


### PR DESCRIPTION
For some reason we had `Raid.raider` and `Host.hoster` fields. Just rename them all to `username`. 