### PR TITLE
Pusher Endpoints

### DIFF
--- a/avalonstar/apps/api/urls.py
+++ b/avalonstar/apps/api/urls.py
@@ -3,7 +3,9 @@ from django.conf.urls import patterns, url, include
 
 from rest_framework import routers
 
-from .views import BroadcastViewSet, HostViewSet, RaidViewSet, TicketViewSet
+from .views import (BroadcastViewSet, HostViewSet, RaidViewSet, TicketViewSet,
+    PusherHostView, PusherResubscriptionView, PusherSubscriptionView,
+    PusherSubstreakView)
 
 
 router = routers.DefaultRouter()
@@ -13,5 +15,11 @@ router.register(r'raids', RaidViewSet)
 router.register(r'tickets', TicketViewSet)
 
 urlpatterns = patterns('',
+    # Pusher.
+    url(r'^pusher/host/$', name='pusher-host', view=PusherHostView.as_view()),
+    url(r'^pusher/resubscription/$', name='pusher-resubscription', view=PusherResubscriptionView.as_view()),
+    url(r'^pusher/subscription/$', name='pusher-subscription', view=PusherSubscriptionView.as_view()),
+    url(r'^pusher/substreak/$', name='pusher-substreak', view=PusherSubstreakView.as_view()),
+
     url(r'^', include(router.urls)),
 )

--- a/avalonstar/apps/api/views.py
+++ b/avalonstar/apps/api/views.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from django.shortcuts import get_object_or_404
 
-from rest_framework import viewsets
+from rest_framework import views, viewsets
 from rest_framework.response import Response
+from pusher import Config, Pusher
 
 from apps.broadcasts.models import Broadcast, Host, Raid, Series
 from apps.games.models import Game
@@ -36,3 +38,26 @@ class TicketViewSet(viewsets.ModelViewSet):
         ticket = get_object_or_404(queryset, name=pk)
         serializer = TicketSerializer(ticket)
         return Response(serializer.data)
+
+
+# Pusher.
+pusher = Pusher(config=Config(
+    app_id=settings.PUSHER_APP_ID,
+    key=settings.PUSHER_KEY,
+    secret=settings.PUSHER_SECRET))
+
+
+class PusherSubscription(views.APIView):
+    pass
+
+
+class PusherResubscription(views.APIView):
+    pass
+
+
+class PusherSubstreak(views.APIView):
+    pass
+
+
+class PusherDonation(views.APIView):
+    pass

--- a/avalonstar/apps/api/views.py
+++ b/avalonstar/apps/api/views.py
@@ -27,6 +27,10 @@ class HostViewSet(viewsets.ModelViewSet):
     queryset = Host.objects.order_by('-timestamp')
     serializer_class = HostSerializer
 
+    def create(self, request, *args, **kwargs):
+        notify('hosted', {'username': request.data['username']})
+        return super(HostViewSet, self).update(request, *args, **kwargs)
+
 
 class RaidViewSet(viewsets.ModelViewSet):
     queryset = Raid.objects.order_by('-timestamp')
@@ -37,11 +41,23 @@ class TicketViewSet(viewsets.ModelViewSet):
     queryset = Ticket.objects.order_by('-updated')
     serializer_class = TicketSerializer
 
+    def create(self, request, *args, **kwargs):
+        notify('subscribed', {'username': request.data['username']})
+        return super(TicketViewSet, self).update(request, *args, **kwargs)
+
     def retrieve(self, request, pk=None):
         queryset = Ticket.objects.all()
         ticket = get_object_or_404(queryset, name=pk)
         serializer = TicketSerializer(ticket)
         return Response(serializer.data)
+
+    def update(self, request, *args, **kwargs):
+        notify('resubscribed', {'username': request.data['username']})
+
+        notify('substreak', {
+            'length': request.data['length'],
+            'username': request.data['username']})
+        return super(TicketViewSet, self).update(request, *args, **kwargs)
 
 
 # Pusher.

--- a/avalonstar/apps/api/views.py
+++ b/avalonstar/apps/api/views.py
@@ -52,11 +52,14 @@ class TicketViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
     def update(self, request, *args, **kwargs):
-        notify('resubscribed', {'username': request.data['username']})
-
-        notify('substreak', {
-            'length': request.data['length'],
-            'username': request.data['username']})
+        # If 'length' is included in the payload, then we consider it a
+        # "substreak" and should notify() as such.
+        if 'length' in request.data:
+            notify('substreak', {
+                'length': request.data['length'],
+                'username': request.data['username']})
+        else:
+            notify('resubscribed', {'username': request.data['username']})
         return super(TicketViewSet, self).update(request, *args, **kwargs)
 
 

--- a/avalonstar/apps/api/views.py
+++ b/avalonstar/apps/api/views.py
@@ -43,7 +43,7 @@ class TicketViewSet(viewsets.ModelViewSet):
 
     def create(self, request, *args, **kwargs):
         notify('subscribed', {'username': request.data['username']})
-        return super(TicketViewSet, self).update(request, *args, **kwargs)
+        return super(TicketViewSet, self).create(request, *args, **kwargs)
 
     def retrieve(self, request, pk=None):
         queryset = Ticket.objects.all()

--- a/avalonstar/apps/api/views.py
+++ b/avalonstar/apps/api/views.py
@@ -14,6 +14,10 @@ from .serializers import (BroadcastSerializer, GameSerializer, HostSerializer,
     RaidSerializer, SeriesSerializer, TicketSerializer)
 
 
+def notify(event, data):
+    pusher['live'].trigger(event, data)
+
+
 class BroadcastViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Broadcast.objects.order_by('-number')
     serializer_class = BroadcastSerializer
@@ -53,23 +57,23 @@ class PusherDonationView(views.APIView):
 
 class PusherHostView(views.APIView):
     def post(self, request):
-        pusher['live'].trigger('hosted', request.data)
+        notify('hosted', request.data)
         return Response(status=202)
 
 
 class PusherResubscriptionView(views.APIView):
     def post(self, request):
-        pusher['live'].trigger('resubscribed', request.data)
+        notify('resubscribed', request.data)
         return Response(status=202)
 
 
 class PusherSubscriptionView(views.APIView):
     def post(self, request):
-        pusher['live'].trigger('subscribed', request.data)
+        notify('subscribed', request.data)
         return Response(status=202)
 
 
 class PusherSubstreakView(views.APIView):
     def post(self, request):
-        pusher['live'].trigger('substreaked', request.data)
+        notify('substreaked', request.data)
         return Response(status=202)

--- a/avalonstar/apps/api/views.py
+++ b/avalonstar/apps/api/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import get_object_or_404
 
 from rest_framework import views, viewsets
 from rest_framework.response import Response
-from pusher import Config, Pusher
+from pusher import Pusher
 
 from apps.broadcasts.models import Broadcast, Host, Raid, Series
 from apps.games.models import Game
@@ -41,23 +41,35 @@ class TicketViewSet(viewsets.ModelViewSet):
 
 
 # Pusher.
-pusher = Pusher(config=Config(
+pusher = Pusher(
     app_id=settings.PUSHER_APP_ID,
     key=settings.PUSHER_KEY,
-    secret=settings.PUSHER_SECRET))
+    secret=settings.PUSHER_SECRET)
 
 
-class PusherSubscription(views.APIView):
+class PusherDonationView(views.APIView):
     pass
 
 
-class PusherResubscription(views.APIView):
-    pass
+class PusherHostView(views.APIView):
+    def post(self, request):
+        pusher['live'].trigger('hosted', request.data)
+        return Response(status=202)
 
 
-class PusherSubstreak(views.APIView):
-    pass
+class PusherResubscriptionView(views.APIView):
+    def post(self, request):
+        pusher['live'].trigger('resubscribed', request.data)
+        return Response(status=202)
 
 
-class PusherDonation(views.APIView):
-    pass
+class PusherSubscriptionView(views.APIView):
+    def post(self, request):
+        pusher['live'].trigger('subscribed', request.data)
+        return Response(status=202)
+
+
+class PusherSubstreakView(views.APIView):
+    def post(self, request):
+        pusher['live'].trigger('substreaked', request.data)
+        return Response(status=202)

--- a/avalonstar/apps/api/views.py
+++ b/avalonstar/apps/api/views.py
@@ -55,7 +55,7 @@ class TicketViewSet(viewsets.ModelViewSet):
         # If 'length' is included in the payload, then we consider it a
         # "substreak" and should notify() as such.
         if 'length' in request.data:
-            notify('substreak', {
+            notify('substreaked', {
                 'length': request.data['length'],
                 'username': request.data['username']})
         else:

--- a/avalonstar/apps/api/views.py
+++ b/avalonstar/apps/api/views.py
@@ -42,7 +42,8 @@ class TicketViewSet(viewsets.ModelViewSet):
     serializer_class = TicketSerializer
 
     def create(self, request, *args, **kwargs):
-        notify('subscribed', {'username': request.data['username']})
+        # TODO: Somehow sync the use of "name" and "username" across methods.
+        notify('subscribed', {'username': request.data['name']})
         return super(TicketViewSet, self).create(request, *args, **kwargs)
 
     def retrieve(self, request, pk=None):

--- a/avalonstar/apps/api/views.py
+++ b/avalonstar/apps/api/views.py
@@ -52,16 +52,24 @@ class TicketViewSet(viewsets.ModelViewSet):
         serializer = TicketSerializer(ticket)
         return Response(serializer.data)
 
-    def update(self, request, *args, **kwargs):
-        # If 'length' is included in the payload, then we consider it a
+    def update(self, request, pk=None):
+        queryset = Ticket.objects.all()
+        ticket = get_object_or_404(queryset, name=pk)
+
+        request.data['name'] = ticket.name
+        serializer = TicketSerializer(ticket, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+
+        # If 'streak' is included in the payload, then we consider it a
         # "substreak" and should notify() as such.
-        if 'length' in request.data:
+        if 'streak' in request.data:
             notify('substreaked', {
-                'length': request.data['length'],
-                'username': request.data['username']})
+                'length': request.data['streak'],
+                'username': ticket.name})
         else:
-            notify('resubscribed', {'username': request.data['username']})
-        return super(TicketViewSet, self).update(request, *args, **kwargs)
+            notify('resubscribed', {'username': ticket.name})
+        return Response(serializer.data)
 
 
 # Pusher.

--- a/avalonstar/apps/subscribers/management/commands/updatetickets.py
+++ b/avalonstar/apps/subscribers/management/commands/updatetickets.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
+logger = logging.getLogger(__name__)
+
 import requests
 import os
 
@@ -9,7 +11,6 @@ from apps.subscribers.models import Ticket
 
 
 class Command(NoArgsCommand):
-    logger = logging.getLogger(__name__)
     help = u'Loops through all subscribers and marks each ticket appropriately.'
 
     def handle_noargs(self, **options):

--- a/avalonstar/settings/base.py
+++ b/avalonstar/settings/base.py
@@ -129,3 +129,9 @@ class Base(Configuration):
             'rest_framework.authentication.TokenAuthentication'
         )
     }
+
+    # pusher.
+    # --------------------------------------------------------------------------
+    PUSHER_APP_ID = values.SecretValue(environ_prefix='')
+    PUSHER_KEY = values.SecretValue(environ_prefix='')
+    PUSHER_SECRET = values.SecretValue(environ_prefix='')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,6 @@ django-model-utils == 2.2
 djangorestframework == 3.1.1
 Pillow == 2.8.0
 psycopg2 == 2.6
-pusher-rest == 0.1.0
+pusher == 0.8
 requests == 2.6.0
 whitenoise == 1.0.6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,5 +11,6 @@ django-model-utils == 2.2
 djangorestframework == 3.1.1
 Pillow == 2.8.0
 psycopg2 == 2.6
+pusher-rest == 0.1.0
 requests == 2.6.0
 whitenoise == 1.0.6


### PR DESCRIPTION
Tried to get Pusher working in our new bryanveloso/avalonstar-dashboard project. Figured that we should again have a "single source of truth" with respect to how we trigger the notification overlay. 

This adds a couple of API endpoints that will trigger the API.